### PR TITLE
Allow MXL format

### DIFF
--- a/musdl.py
+++ b/musdl.py
@@ -45,23 +45,14 @@ def download_score(format, url):
         re_score = REGEXES[format]
 
     try:
-        soup = bsoup.BeautifulSoup(
-            requests.get(url).content,
-            "html5lib"
-        )
+        soup = bsoup.BeautifulSoup(requests.get(url).content, "html5lib")
     except requests.ConnectionError as e:
         raise DownloadError("could not get website data: " + str(e))
-    
+
     # urls for scores are stored in a js-store class, there is only one per page
-    class_content = str(
-        soup.find_all(
-            "div", {"class": "js-store"}
-        )[0]
-    )
-    score_data_url = re.findall(
-        re_score, class_content
-    )[0]
-    
+    class_content = str(soup.find_all("div", {"class": "js-store"})[0])
+    score_data_url = re.findall(re_score, class_content)[0]
+
     try:
         score_data = requests.get(score_data_url)
     except requests.ConnectionError as e:
@@ -73,50 +64,41 @@ def download_score(format, url):
 def main(args=None):
     if args == None:
         args = sys.argv[1:]
-    parser = argparse.ArgumentParser(
-        prog="musdl",
-        description=__doc__,
-    )
-    
+    parser = argparse.ArgumentParser(prog="musdl", description=__doc__)
+
     parser.add_argument(
-        "-V", "--version",
+        "-V",
+        "--version",
         help="print version",
         action="version",
-        version="%(prog)s v{}".format(
-            __version__
-        )
+        version="%(prog)s v{}".format(__version__),
     )
-    
+
     parser.add_argument(
-        "-f", "--format",
-        choices=[
-            "midi",
-            "mp3",
-        ],
+        "-f",
+        "--format",
+        choices=["midi", "mp3"],
         default="mp3",
         help="format to download, defaults to mp3",
         action="store",
     )
-    
+
     parser.add_argument(
-        "-o", "--output",
+        "-o",
+        "--output",
         help="file to output the score to, otherwise stdout",
         action="store",
     )
-    
-    parser.add_argument(
-        "url",
-        help="url of the score",
-        action="store",
-    )
+
+    parser.add_argument("url", help="url of the score", action="store")
     options = parser.parse_args(args)
-    
+
     score_data = download_score(options.format, options.url)
-    
+
     if options.output:
         with open(options.output, mode="wb") as f:
             f.write(score_data)
-    
+
     else:
         print(score_data)
 

--- a/musdl.py
+++ b/musdl.py
@@ -18,7 +18,10 @@ __license__ = "MIT"
 REGEXES = {
     "midi": r"http[s]?://musescore.com/static/musescore/scoredata/gen/[a-zA-Z0-9/]*score\.mid",
     "mp3": r"http[s]?://nocdn.musescore.com/static/musescore/scoredata/gen/[a-zA-Z0-9/]*score\.mp3",
+    "mxl": r"http[s]?://nocdn.musescore.com/static/musescore/scoredata/gen/[a-zA-Z0-9/]*score\.mp3",
 }
+
+ALLOWED_FORMATS = ["mp3", "midi", "mxl"]
 
 
 class DownloadError(Exception):
@@ -39,7 +42,7 @@ def download_score(format, url):
     """
     if "musescore.com" not in url:
         raise DownloadError("not a musescore url")
-    elif format not in ("midi", "mp3"):
+    elif format not in ALLOWED_FORMATS:
         raise DownloadError("format must be mid or mp3")
     else:
         re_score = REGEXES[format]
@@ -52,6 +55,11 @@ def download_score(format, url):
     # urls for scores are stored in a js-store class, there is only one per page
     class_content = str(soup.find_all("div", {"class": "js-store"})[0])
     score_data_url = re.findall(re_score, class_content)[0]
+
+    # The URL for the mxl file is not present in the downloaded html page and it is
+    # built from the mp3 URL
+    if format == "mxl":
+        score_data_url = re.sub(r"\.mp3$", ".mxl", score_data_url, flags=re.IGNORECASE)
 
     try:
         score_data = requests.get(score_data_url)
@@ -77,7 +85,7 @@ def main(args=None):
     parser.add_argument(
         "-f",
         "--format",
-        choices=["midi", "mp3"],
+        choices=ALLOWED_FORMATS,
         default="mp3",
         help="format to download, defaults to mp3",
         action="store",


### PR DESCRIPTION
Hi,

your library is nice but it was missing the MXL download option. This is to download the music sheet, which can then be imported into a music sheet software.

I'd also appreciate the PDF format, but I couldn't figure out the download URL. If you know how it's built, would you mind adding it to the available formats?

I also ran Black on the code, sorry for the unnecessary high lines count.